### PR TITLE
Map commands

### DIFF
--- a/addons/godot_vim/commands/goto.gd
+++ b/addons/godot_vim/commands/goto.gd
@@ -2,5 +2,5 @@ const Constants = preload("res://addons/godot_vim/constants.gd")
 const Mode = Constants.Mode
 
 func execute(api, args):
-	api.cursor.set_caret_pos(args.to_int(), 0)
+	api.cursor.set_caret_pos(args.to_int() - 1, 0)
 	api.cursor.set_mode(Mode.NORMAL)

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -1,26 +1,89 @@
 class_name KeyMap extends RefCounted
 ## Hanldes input stream and key mapping
 
+const Constants = preload("res://addons/godot_vim/constants.gd")
+const Mode = Constants.Mode
 
-enum CmdType {
+
+enum {
 	Motion,
 	Operator,
+	OperatorMotion,
 	Action,
-	Incomplete, # Await input
 }
 
-enum MotionArgs {
+enum MotionType {
 	MoveByChars,
 	MoveByLines,
+	ToLineStart,
+	ToLineEnd,
+	MoveByWord,
+	StartOfLine,
+	EndOfLine,
+	FirstNonWhitespaceChar,
+}
+
+enum ActionType {
+	Insert,
+	Visual,
+	Undo,
+	Redo,
+	Join,
+}
+
+enum OperatorType {
+	Delete,
+	Change,
+	Yank,
+	Paste,
 }
 
 
 # `static var` doesn't work
 const key_map: Array[Dictionary] = [
-	{ "keys": ["h"], "cmds": [ { "type": CmdType.Motion, MotionArgs.MoveByChars: -1 } ] },
-	{ "keys": ["l"], "cmds": [ { "type": CmdType.Motion, MotionArgs.MoveByChars: 1 } ] },
-	{ "keys": ["j"], "cmds": [ { "type": CmdType.Motion, MotionArgs.MoveByLines: 1 } ] },
-	{ "keys": ["k"], "cmds": [ { "type": CmdType.Motion, MotionArgs.MoveByLines: -1 } ] },
+	{ "keys": ["h"], "type": Motion, "motion": { "type": MotionType.MoveByChars, "move_by": -1 } },
+	{ "keys": ["l"], "type": Motion, "motion": { "type": MotionType.MoveByChars, "move_by": 1 } },
+	{ "keys": ["j"], "type": Motion, "motion": { "type": MotionType.MoveByLines, "move_by": 1 } },
+	{ "keys": ["k"], "type": Motion, "motion": { "type": MotionType.MoveByLines, "move_by": -1 } },
+	{ "keys": ["w"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": true, "word_end": false } },
+	{ "keys": ["e"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": true, "word_end": true } },
+	{ "keys": ["b"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": false, "word_end": false } },
+	{ "keys": ["g", "e"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": false, "word_end": true } },
+	{ "keys": ["W"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": true, "word_end": false, "big_word": true } },
+	{ "keys": ["E"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": true, "word_end": true, "big_word": true } },
+	{ "keys": ["B"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": false, "word_end": false, "big_word": true } },
+	{ "keys": ["g", "E"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": false, "word_end": true, "big_word": true } },
+	{ "keys": ["0"], "type": Motion, "motion": { "type": MotionType.StartOfLine } },
+	{ "keys": ["$"], "type": Motion, "motion": { "type": MotionType.EndOfLine } },
+	{ "keys": ["^"], "type": Motion, "motion": { "type": MotionType.FirstNonWhitespaceChar } },
+	
+	{ "keys": ["x"], "type": OperatorMotion, "context": Mode.NORMAL,
+		"operator": { "type": OperatorType.Delete },
+		"motion": { "type": MotionType.MoveByChars, "move_by": 1 }
+	},
+	{ "keys": ["x"], "type": OperatorMotion, "context": Mode.VISUAL,
+		"operator": { "type": OperatorType.Delete },
+		"motion": { "type": MotionType.MoveByChars, "move_by": 1 }
+	},
+	{ "keys": ["D"], "type": OperatorMotion, "context": Mode.NORMAL,
+		"operator": { "type": OperatorType.Delete },
+		"motion": { "type": MotionType.EndOfLine, "inclusive": true }
+	},
+	{ "keys": ["p"], "type": OperatorMotion,
+		"operator": { "type": OperatorType.Paste },
+		"motion": { "type": MotionType.MoveByChars, "move_by": 1 }
+	},
+	
+	{ "keys": ["i"], "type": Action, "action": { "type": ActionType.Insert } },
+	{ "keys": ["a"], "type": Action, "action": { "type": ActionType.Insert, "offset": "after" } },
+	{ "keys": ["I"], "type": Action, "action": { "type": ActionType.Insert, "offset": "bol" } },
+	{ "keys": ["A"], "type": Action, "action": { "type": ActionType.Insert, "offset": "eol" } },
+	{ "keys": ["o"], "type": Action, "action": { "type": ActionType.Insert, "offset": "new_line_below" } },
+	{ "keys": ["O"], "type": Action, "action": { "type": ActionType.Insert, "offset": "new_line_above" } },
+	{ "keys": ["v"], "type": Action, "action": { "type": ActionType.Visual } },
+	{ "keys": ["u"], "type": Action, "action": { "type": ActionType.Undo } },
+	{ "keys": ["<C-r>"], "type": Action, "action": { "type": ActionType.Redo } },
+	{ "keys": ["J"], "type": Action, "action": { "type": ActionType.Join } },
 ]
 
 # `static var` also doesn't work
@@ -33,16 +96,24 @@ var input_stream: Array[String] = []
 
 
 ## Returns: Array[Dictionary]
-func register_event(event: InputEventKey) -> Array:
+func register_event(event: InputEventKey, with_context: Mode) -> Dictionary:
 	var ch: String = get_event_char(event)
-	print("[KeyMap::register_event()] registered event: ", ch) # DEBUG
+	if ch.is_empty():	return {} # Invalid
+	if whitelist.has(ch):	return {}
+	
+	# print("[KeyMap] registering event: ", ch) # DEBUG
 	input_stream.append(ch)
 	
+	# Find command
 	for keymap in key_map:
+		if keymap.has("context") and with_context != keymap.context:	continue
+		
 		if !do_keys_match(input_stream, keymap.keys):	continue
-		clear()
-		return keymap.cmds
-	return []
+		
+		call_deferred(&"clear")
+		# print("[KeyMap] registered cmd: ", keymap) # DEBUG
+		return keymap
+	return {}
 
 
 static func get_event_char(event: InputEventKey) -> String:
@@ -51,6 +122,8 @@ static func get_event_char(event: InputEventKey) -> String:
 	if event.keycode == KEY_TAB:
 		return "<TAB>"
 	if event.is_command_or_control_pressed():
+		if !OS.is_keycode_unicode(event.keycode):
+			return ''
 		var c: String = char(event.keycode)
 		return "<C-%s>" % [ c if event.shift_pressed else c.to_lower() ]
 	return char(event.unicode)

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -1,0 +1,73 @@
+class_name KeyMap
+## Hanldes input stream and key mapping
+
+
+enum Type {
+	Motion,
+	Operator,
+	Action,
+	Incomplete, # Await input
+}
+
+enum Motion {
+	MoveX,
+	MoveY,
+}
+
+
+static var key_map: Array[Dictionary] = [
+	{ "keys": ["j"], "type": Type.Motion, "motion": Motion.MoveX }
+]
+
+static var whitelist = [
+	"<C-s>"
+]
+
+
+static var input_stream: String = ""
+
+
+static func register_event(event: InputEventKey) -> Dictionary:
+	var ch: String = get_event_char(event)
+	# print("[KeyMap::register_event()] registered event: ", ch) # DEBUG
+	input_stream += ch
+	
+	var a: Array = split_count(input_stream)
+	if a.is_empty():	return {}
+	
+	var count: int = a[0]
+	var cmd: String = a[1]
+	return {
+		'count' : count,
+		'cmd' : cmd,
+	}
+
+
+static func get_event_char(event: InputEventKey) -> String:
+	if event.keycode == KEY_ENTER:
+		return "<CR>"
+	if event.keycode == KEY_TAB:
+		return "<TAB>"
+	if event.is_command_or_control_pressed():
+		var c: String = char(event.keycode)
+		return "<C-%s>" % [ c if event.shift_pressed else c.to_lower() ]
+	return char(event.unicode)
+
+
+static func clear_input_stream():
+	input_stream = ""
+
+
+
+# returns:
+#  [] if invalid / incomplete
+#  [ count: int, rest of the string: String ]
+static func split_count(str: String) -> Array:
+	if str.is_empty():	return []
+	if str[0] == '0':	return [] # Those that start with '0' is are exceptions
+	for i in str.length():
+		if !'0123456789'.contains(str[i]):
+			return [ maxi(str.left(i).to_int(), 1), str.substr(i) ]
+	return [] # All digits
+
+

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -6,84 +6,82 @@ const Mode = Constants.Mode
 
 
 enum {
+	## Moves the cursor. Can be used in tandem with Operator
 	Motion,
+	
+	## Commands like delete, yank
+	## Can be executed as-is in Visual mode (e.g. d, c). In Normal mode, they need a Motion or another
+	##  Operator bound to them (e.g. dj, yy)
 	Operator,
+	
+	## Operator but with a motion already bound to it
+	## Cannot be executed in Visual mode
 	OperatorMotion,
+	
+	## A single action (e.g. i, o, v, J, u)
 	Action,
 }
 
-enum MotionType {
-	MoveByChars,
-	MoveByLines,
-	ToLineStart,
-	ToLineEnd,
-	MoveByWord,
-	StartOfLine,
-	EndOfLine,
-	FirstNonWhitespaceChar,
-}
-
-enum ActionType {
-	Insert,
-	Visual,
-	Undo,
-	Redo,
-	Join,
-}
-
-enum OperatorType {
-	Delete,
-	Change,
-	Yank,
-	Paste,
-}
+#enum OperatorType {
+#	Delete,
+#	Change,
+#	Yank,
+#	Paste,
+#}
 
 
 # `static var` doesn't work
+# Also see the "COMMANDS" section at the bottom of cursor.gd
+#  Command for     { "type": "foo", ... }   is handled in Cursor::cmd_foo(args: Dictionary)
+#  where `args` is ^^^^^ this Dict ^^^^^^
 const key_map: Array[Dictionary] = [
-	{ "keys": ["h"], "type": Motion, "motion": { "type": MotionType.MoveByChars, "move_by": -1 } },
-	{ "keys": ["l"], "type": Motion, "motion": { "type": MotionType.MoveByChars, "move_by": 1 } },
-	{ "keys": ["j"], "type": Motion, "motion": { "type": MotionType.MoveByLines, "move_by": 1 } },
-	{ "keys": ["k"], "type": Motion, "motion": { "type": MotionType.MoveByLines, "move_by": -1 } },
-	{ "keys": ["w"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": true, "word_end": false } },
-	{ "keys": ["e"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": true, "word_end": true } },
-	{ "keys": ["b"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": false, "word_end": false } },
-	{ "keys": ["g", "e"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": false, "word_end": true } },
-	{ "keys": ["W"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": true, "word_end": false, "big_word": true } },
-	{ "keys": ["E"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": true, "word_end": true, "big_word": true } },
-	{ "keys": ["B"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": false, "word_end": false, "big_word": true } },
-	{ "keys": ["g", "E"], "type": Motion, "motion": { "type": MotionType.MoveByWord, "forward": false, "word_end": true, "big_word": true } },
-	{ "keys": ["0"], "type": Motion, "motion": { "type": MotionType.StartOfLine } },
-	{ "keys": ["$"], "type": Motion, "motion": { "type": MotionType.EndOfLine } },
-	{ "keys": ["^"], "type": Motion, "motion": { "type": MotionType.FirstNonWhitespaceChar } },
+	# MOTIONS
+	{ "keys": ["h"], "type": Motion, "motion": { "type": "move_by_chars", "move_by": -1 } },
+	{ "keys": ["l"], "type": Motion, "motion": { "type": "move_by_chars", "move_by": 1 } },
+	{ "keys": ["j"], "type": Motion, "motion": { "type": "move_by_lines", "move_by": 1, "line_wise": true } },
+	{ "keys": ["k"], "type": Motion, "motion": { "type": "move_by_lines", "move_by": -1, "line_wise": true } },
+	{ "keys": ["w"], "type": Motion, "motion": { "type": "move_by_word", "forward": true, "word_end": false } },
+	{ "keys": ["e"], "type": Motion, "motion": { "type": "move_by_word", "forward": true, "word_end": true } },
+	{ "keys": ["b"], "type": Motion, "motion": { "type": "move_by_word", "forward": false, "word_end": false } },
+	{ "keys": ["g", "e"], "type": Motion, "motion": { "type": "move_by_word", "forward": false, "word_end": true } },
+	{ "keys": ["W"], "type": Motion, "motion": { "type": "move_by_word", "forward": true, "word_end": false, "big_word": true } },
+	{ "keys": ["E"], "type": Motion, "motion": { "type": "move_by_word", "forward": true, "word_end": true, "big_word": true } },
+	{ "keys": ["B"], "type": Motion, "motion": { "type": "move_by_word", "forward": false, "word_end": false, "big_word": true } },
+	{ "keys": ["g", "E"], "type": Motion, "motion": { "type": "move_by_word", "forward": false, "word_end": true, "big_word": true } },
+	{ "keys": ["0"], "type": Motion, "motion": { "type": "move_to_bol" } },
+	{ "keys": ["$"], "type": Motion, "motion": { "type": "move_to_eol" } },
+	{ "keys": ["^"], "type": Motion, "motion": { "type": "move_to_first_non_whitespace_char" } },
 	
-	{ "keys": ["x"], "type": OperatorMotion, "context": Mode.NORMAL,
-		"operator": { "type": OperatorType.Delete },
-		"motion": { "type": MotionType.MoveByChars, "move_by": 1 }
+	# OPERATORS
+	{ "keys": ["x"], "type": OperatorMotion,
+		"operator": { "type": "delete" },
+		"motion": { "type": "move_by_chars", "move_by": 1 }
 	},
-	{ "keys": ["x"], "type": OperatorMotion, "context": Mode.VISUAL,
-		"operator": { "type": OperatorType.Delete },
-		"motion": { "type": MotionType.MoveByChars, "move_by": 1 }
-	},
+	{ "keys": ["d"], "type": Operator, "operator": { "type": "delete" } },
+	{ "keys": ["x"], "type": Operator, "context": Mode.VISUAL, "operator": { "type": "delete" } },
+
 	{ "keys": ["D"], "type": OperatorMotion, "context": Mode.NORMAL,
-		"operator": { "type": OperatorType.Delete },
-		"motion": { "type": MotionType.EndOfLine, "inclusive": true }
-	},
-	{ "keys": ["p"], "type": OperatorMotion,
-		"operator": { "type": OperatorType.Paste },
-		"motion": { "type": MotionType.MoveByChars, "move_by": 1 }
+		"operator": { "type": "delete" },
+		"motion": { "type": "move_to_eol", "inclusive": true }
 	},
 	
-	{ "keys": ["i"], "type": Action, "action": { "type": ActionType.Insert } },
-	{ "keys": ["a"], "type": Action, "action": { "type": ActionType.Insert, "offset": "after" } },
-	{ "keys": ["I"], "type": Action, "action": { "type": ActionType.Insert, "offset": "bol" } },
-	{ "keys": ["A"], "type": Action, "action": { "type": ActionType.Insert, "offset": "eol" } },
-	{ "keys": ["o"], "type": Action, "action": { "type": ActionType.Insert, "offset": "new_line_below" } },
-	{ "keys": ["O"], "type": Action, "action": { "type": ActionType.Insert, "offset": "new_line_above" } },
-	{ "keys": ["v"], "type": Action, "action": { "type": ActionType.Visual } },
-	{ "keys": ["u"], "type": Action, "action": { "type": ActionType.Undo } },
-	{ "keys": ["<C-r>"], "type": Action, "action": { "type": ActionType.Redo } },
-	{ "keys": ["J"], "type": Action, "action": { "type": ActionType.Join } },
+	{ "keys": ["p"], "type": OperatorMotion,
+		"operator": { "type": "paste" },
+		"motion": { "type": "move_by_chars", "move_by": 1 }
+	},
+		
+	# ACTIONS
+	{ "keys": ["i"], "type": Action, "action": { "type": "insert" } },
+	{ "keys": ["a"], "type": Action, "action": { "type": "insert", "offset": "after" } },
+	{ "keys": ["I"], "type": Action, "action": { "type": "insert", "offset": "bol" } },
+	{ "keys": ["A"], "type": Action, "action": { "type": "insert", "offset": "eol" } },
+	{ "keys": ["o"], "type": Action, "action": { "type": "insert", "offset": "new_line_below" } },
+	{ "keys": ["O"], "type": Action, "action": { "type": "insert", "offset": "new_line_above" } },
+	{ "keys": ["v"], "type": Action, "action": { "type": "visual" } },
+	{ "keys": ["V"], "type": Action, "action": { "type": "visual_line" } },
+	{ "keys": ["u"], "type": Action, "action": { "type": "undo" } },
+	{ "keys": ["<C-r>"], "type": Action, "action": { "type": "redo" } },
+	{ "keys": ["J"], "type": Action, "action": { "type": "join" } },
 ]
 
 # `static var` also doesn't work
@@ -93,6 +91,11 @@ const whitelist = [
 
 
 var input_stream: Array[String] = []
+var cursor: Control
+
+
+func _init(cursor_: Control):
+	cursor = cursor_
 
 
 ## Returns: Array[Dictionary]
@@ -101,19 +104,115 @@ func register_event(event: InputEventKey, with_context: Mode) -> Dictionary:
 	if ch.is_empty():	return {} # Invalid
 	if whitelist.has(ch):	return {}
 	
-	# print("[KeyMap] registering event: ", ch) # DEBUG
+	# print("[KeyMap::register_event()] ch = ", ch) # DEBUG
 	input_stream.append(ch)
+	var cmd: Dictionary = parse_keys(input_stream, with_context)
+	if cmd.is_empty():
+		return {}
 	
-	# Find command
-	for keymap in key_map:
-		if keymap.has("context") and with_context != keymap.context:	continue
-		
-		if !do_keys_match(input_stream, keymap.keys):	continue
-		
+	execute(cmd)
+	return cmd
+
+
+func parse_keys(keys: Array[String], with_context: Mode) -> Dictionary:
+	var cmd: Dictionary = find_cmd(keys, with_context)
+	# print('cmd: ', cmd)
+	if cmd.is_empty():
 		call_deferred(&"clear")
-		# print("[KeyMap] registered cmd: ", keymap) # DEBUG
-		return keymap
+		return {}
+	
+	# Execute the operation as-is if in VISUAL mode
+	# If in NORMAL mode, await further input
+	if cmd.type == Operator and with_context == Mode.NORMAL:
+		var op_args: Array[String] = keys.slice( cmd.keys.size() ) # Get the rest of keys
+		# print('op_args: ', op_args)
+		if op_args.is_empty(): # Incomplete; await further input
+			return {}
+		
+		var next: Dictionary = find_cmd(op_args, with_context)
+		if next.is_empty(): # Invalid sequence
+			call_deferred(&"clear")
+			return {}
+		
+		cmd = cmd.duplicate()
+		cmd.modifier = next
+	
+	call_deferred(&"clear")
+	return cmd
+
+
+# TODO clean up
+func find_cmd(keys: Array[String], with_context: Mode) -> Dictionary:
+	for cmd in key_map:
+		# OperatorMotions in visual mode aren't allowed
+		if cmd.type == OperatorMotion and with_context != Mode.NORMAL:
+			continue
+		
+		# Allow Operators to be executed as-is in visual mode
+		var skip_ctxcheck: bool = false
+		if cmd.type == Operator and with_context != Mode.NORMAL:
+			skip_ctxcheck = true
+		
+		if !skip_ctxcheck and cmd.has("context") and with_context != cmd.context: # Check context
+			continue
+		
+		if !do_keys_contain(cmd.keys, keys):
+			continue
+		return cmd
 	return {}
+
+	# TODO try this:
+	# for cmd in key_map.filter( check for context... ):
+	# 	check for keys...
+	# 	return cmd
+	# return {}
+
+
+func execute(cmd: Dictionary):
+	# `if else` is faster than `match` (especially with small sets)
+	if cmd.type == Motion:
+		var pos: Vector2i = call_cmd(cmd.motion)
+		cursor.set_caret_pos(pos.y, pos.x)
+		return
+	
+	if cmd.type == OperatorMotion:
+		execute_operator_motion(cmd.operator, cmd.motion)
+		return
+	
+	if cmd.type == Operator:
+		print("[KeyMay::execute()] op: ", cmd)
+		if !cmd.has("modifier"): # Execute as-is
+			call_cmd(cmd.operator)
+			return
+		
+		if cmd.modifier.type == Motion:
+			execute_operator_motion(cmd.operator, cmd.modifier.motion)
+		
+		return
+	
+	if cmd.type == Action:
+		call_cmd(cmd.action)
+		return
+	
+	push_error("[KeyMap::execute()] Unknown command type: %s" % cmd.type)
+
+
+func execute_operator_motion(operator: Dictionary, motion: Dictionary):
+	print("[KeyMay::execute_operator_motion()] op = ", operator, ", motion = ", motion)
+
+	# Execute motion before operation
+	# TODO line-wise motions (j, k, {, }, gg, G, etc)
+	var p0: Vector2i = cursor.get_caret_pos()
+	var p1: Vector2i = call_cmd(motion)
+	cursor.code_edit.select(p0.y, p0.x, p1.y, p1.x)
+	
+	call_cmd(operator)
+
+
+## Unsafe: does not check if the function exists
+func call_cmd(cmd: Dictionary) -> Variant:
+	var func_name: StringName = StringName("cmd_" + cmd.type)
+	return cursor.call(func_name, cmd)
 
 
 static func get_event_char(event: InputEventKey) -> String:
@@ -136,6 +235,15 @@ static func do_keys_match(a: Array, b: Array) -> bool:
 			return false
 	return true
 
+## Check whether keys [param a] is contained in keys [param b]
+static func do_keys_contain(a: Array, b: Array) -> bool:
+	if b.size() < a.size():
+		return false
+	for i in a.size():
+		if a[i] != b[i]:
+			return false
+	return true
+
 
 func clear():
 	input_stream = []
@@ -143,4 +251,5 @@ func clear():
 
 func get_input_stream_as_string() -> String:
 	return ''.join(PackedStringArray(input_stream))
+
 

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -18,6 +18,7 @@ enum {
 	OperatorMotion,
 	
 	## A single action (e.g. i, o, v, J, u)
+	## Cannot be executed in Visual mode unless specified with "context": Mode.VISUAL
 	Action,
 	
 	Incomplete, ## Incomplete command
@@ -46,6 +47,13 @@ const key_map: Array[Dictionary] = [
 	{ "keys": ["B"], "type": Motion, "motion": { "type": "move_by_word", "forward": false, "word_end": false, "big_word": true } },
 	{ "keys": ["g", "E"], "type": Motion, "motion": { "type": "move_by_word", "forward": false, "word_end": true, "big_word": true } },
 	
+	{ "keys": ["f", "{char}"], "type": Motion, "motion": { "type": "find_in_line", "forward": true, "inclusive": true } },
+	{ "keys": ["t", "{char}"], "type": Motion, "motion": { "type": "find_in_line", "forward": true, "stop_before": true, "inclusive": true } },
+	{ "keys": ["F", "{char}"], "type": Motion, "motion": { "type": "find_in_line", "forward": false } },
+	{ "keys": ["T", "{char}"], "type": Motion, "motion": { "type": "find_in_line", "forward": false, "stop_before": true } },
+	{ "keys": [";"], "type": Motion, "motion": { "type": "find_in_line_again", "invert": false } },
+	{ "keys": [","], "type": Motion, "motion": { "type": "find_in_line_again", "invert": true } },
+	
 	{ "keys": ["0"], "type": Motion, "motion": { "type": "move_to_bol" } },
 	{ "keys": ["$"], "type": Motion, "motion": { "type": "move_to_eol" } },
 	{ "keys": ["^"], "type": Motion, "motion": { "type": "move_to_first_non_whitespace_char" } },
@@ -62,7 +70,6 @@ const key_map: Array[Dictionary] = [
 		"operator": { "type": "delete" },
 		"motion": { "type": "move_to_eol" }
 	},
-	
 	{ "keys": ["x"], "type": OperatorMotion,
 		"operator": { "type": "delete" },
 		"motion": { "type": "move_by_chars", "move_by": 1 }
@@ -79,7 +86,6 @@ const key_map: Array[Dictionary] = [
 		"operator": { "type": "change" },
 		"motion": { "type": "move_to_eol" }
 	},
-	
 	{ "keys": ["s"], "type": OperatorMotion,
 		"operator": { "type": "change" },
 		"motion": { "type": "move_by_chars", "move_by": 1 }
@@ -90,7 +96,12 @@ const key_map: Array[Dictionary] = [
 		"operator": { "type": "paste" },
 		"motion": { "type": "move_by_chars", "move_by": 1 }
 	},
-		
+	{ "keys": ["p"], "type": Operator, "context": Mode.VISUAL, "operator": { "type": "paste" } },
+	
+	{ "keys": [">"], "type": Operator, "operator": { "type": "indent", "forward": true } },
+	{ "keys": ["<"], "type": Operator, "operator": { "type": "indent", "forward": false } },
+	{ "keys": ["g", "c"], "type": Operator, "operator": { "type": "comment" } },
+	
 	# ACTIONS
 	{ "keys": ["i"], "type": Action, "action": { "type": "insert" } },
 	{ "keys": ["a"], "type": Action, "action": { "type": "insert", "offset": "after" } },
@@ -99,18 +110,27 @@ const key_map: Array[Dictionary] = [
 	{ "keys": ["o"], "type": Action, "action": { "type": "insert", "offset": "new_line_below" } },
 	{ "keys": ["O"], "type": Action, "action": { "type": "insert", "offset": "new_line_above" } },
 	{ "keys": ["v"], "type": Action, "action": { "type": "visual" } },
-	{ "keys": ["V"], "type": Action, "action": { "type": "visual_line" } },
+	{ "keys": ["V"], "type": Action, "action": { "type": "visual", "line_wise": true } },
 	{ "keys": ["u"], "type": Action, "action": { "type": "undo" } },
 	{ "keys": ["<C-r>"], "type": Action, "action": { "type": "redo" } },
+	{ "keys": ["r", "{char}"], "type": Action, "action": { "type": "replace" } },
 	{ "keys": [":"], "type": Action, "action": { "type": "command" } },
 	{ "keys": ["/"], "type": Action, "action": { "type": "search" } },
 	{ "keys": ["J"], "type": Action, "action": { "type": "join" } },
+	{ "keys": ["z", "z"], "type": Action, "action": { "type": "center_caret" } },
 ]
 
-# `static var` also doesn't work
-const whitelist = [
-	"<C-s>"
+# Keys we won't handle
+const BLACKLIST: Array[String] = [
+	"<C-s>", # Save
+	"<C-b>", # Bookmark
 ]
+
+enum KeyMatch {
+	None = 0, # Keys don't match
+	Partial = 1, # Keys match partially
+	Full = 2, # Keys match totally
+}
 
 
 var input_stream: Array[String] = []
@@ -119,19 +139,20 @@ var cursor: Control
 
 func _init(cursor_: Control):
 	cursor = cursor_
+	# key_map.make_read_only()
 
 
 ## Returns: Dictionary with the found command: { "type": Motion or Operator or OperatorMotion or Action or Incomplete or NotFound, ... }
-## Warning: the returned Dict can be empty in some cases
+## Warning: the returned Dict can be empty in if the event wasn't processed
 func register_event(event: InputEventKey, with_context: Mode) -> Dictionary:
-	var ch: String = get_event_char(event)
+	var ch: String = event_to_char(event)
 	if ch.is_empty():	return {} # Invalid
-	if whitelist.has(ch):	return {}
+	if BLACKLIST.has(ch):	return {}
 	
 	# print("[KeyMap::register_event()] ch = ", ch) # DEBUG
 	input_stream.append(ch)
 	var cmd: Dictionary = parse_keys(input_stream, with_context)
-	if cmd.is_empty():
+	if cmd.is_empty() or cmd.type in [Incomplete, NotFound]:
 		return { 'type': NotFound }
 	
 	execute(cmd)
@@ -160,7 +181,6 @@ func parse_keys(keys: Array[String], with_context: Mode) -> Dictionary:
 		elif next.type == Incomplete:
 			return { 'type': Incomplete }
 		
-		cmd = cmd.duplicate()
 		cmd.modifier = next
 	
 	call_deferred(&"clear")
@@ -170,24 +190,36 @@ func parse_keys(keys: Array[String], with_context: Mode) -> Dictionary:
 ## The returned cmd will always have a 'type' key
 func find_cmd(keys: Array[String], with_context: Mode) -> Dictionary:
 	var partial: bool = false # In case none were found
+	var is_visual: bool = with_context == Mode.VISUAL or with_context == Mode.VISUAL_LINE
 	
 	for cmd in key_map:
 		# OperatorMotions in visual mode aren't allowed
-		if cmd.type == OperatorMotion and with_context != Mode.NORMAL:
+		if cmd.type == OperatorMotion and is_visual:
+			continue
+		
+		# Don't allow Actions in Visual mode unless specified
+		if cmd.type == Action and is_visual\
+			and !(cmd.has("context") and cursor.is_mode_visual(cmd.context)):
 			continue
 		
 		# Allow Operators to be executed as-is in visual mode
-		if !(cmd.type == Operator and with_context != Mode.NORMAL)\
-			# Check context
-			and (cmd.has("context") and with_context != cmd.context):
-			continue
+		if !(cmd.type == Operator and is_visual):
+			# Check context for other commands
+			if cmd.has("context") and with_context != cmd.context:
+				continue
 		
+		# Check keys
 		var m: KeyMatch = match_keys(cmd.keys, keys)
 		partial = partial or m == KeyMatch.Partial # Set/keep partial = true if it was a partial match
-		if m != KeyMatch.Absolute:
+		if m != KeyMatch.Full:
 			continue
 		
-		return cmd
+		var cmd_mut: Dictionary = cmd.duplicate(true) # 'mut' ('mutable') because key_map is read-only
+		# Keep track of selected character, which will later be copied into the fucntion call for the command
+		# (See execute() where we check if cmd.has('selected_char'))
+		if cmd.keys[-1] == '{char}':
+			cmd_mut.selected_char = keys.back()
+		return cmd_mut
 	# return { "type": Incomplete if partial else NotFound }
 	return { "type": Incomplete*int(partial) + NotFound*int(!partial) }
 
@@ -198,13 +230,16 @@ func execute(cmd: Dictionary):
 	
 	# `if else` is faster than `match` (especially with small sets)
 	if cmd.type == Motion:
-		# print("[KeyMay::execute()] motion: ", cmd) # DEBUG
+		if cmd.has('selected_char'):
+			cmd.motion.selected_char = cmd.selected_char
 		var pos: Vector2i = call_cmd(cmd.motion)
 		cursor.set_caret_pos(pos.y, pos.x)
 		return
 	
 	if cmd.type == OperatorMotion:
 		if cmd.has('motion'):
+			if cmd.has('selected_char'):
+				cmd.motion.selected_char = cmd.selected_char
 			execute_operator_motion(cmd.operator, cmd.motion)
 		else:
 			call_cmd(cmd.operator)
@@ -214,13 +249,17 @@ func execute(cmd: Dictionary):
 		# print("[KeyMay::execute()] op: ", cmd) # DEBUG
 		if !cmd.has("modifier"): # Execute as-is
 			call_cmd(cmd.operator)
+			return
 		
+		var mod: Dictionary = cmd.modifier
 		# Execute with motion
-		elif cmd.modifier.type == Motion:
-			execute_operator_motion(cmd.operator, cmd.modifier.motion)
+		if mod.type == Motion:
+			if mod.has('selected_char'):
+				mod.motion.selected_char = mod.selected_char
+			execute_operator_motion(cmd.operator, mod.motion)
 		
 		# Execute with `line_wise = true` if repeating operations (e.g. dd, yy)
-		elif cmd.modifier.type == Operator and cmd.modifier.operator.type == cmd.operator.type:
+		elif mod.type == Operator and mod.operator.type == cmd.operator.type:
 			var op_cmd: Dictionary = cmd.operator.duplicate()
 			op_cmd.line_wise = true
 			call_cmd(op_cmd)
@@ -228,6 +267,8 @@ func execute(cmd: Dictionary):
 		return
 	
 	if cmd.type == Action:
+		if cmd.has('selected_char'):
+			cmd.action.selected_char = cmd.selected_char
 		call_cmd(cmd.action)
 		return
 	
@@ -239,7 +280,9 @@ func execute_operator_motion(operator: Dictionary, motion: Dictionary):
 
 	# Execute motion before operation
 	var p0: Vector2i = cursor.get_caret_pos()
-	var p1: Vector2i = call_cmd(motion)    + Vector2i(int(motion.get('inclusive', false)), 0)
+	var p1: Vector2i = call_cmd(motion)
+	if motion.get('inclusive', false):
+		p1.x += 1
 	cursor.code_edit.select(p0.y, p0.x, p1.y, p1.x)
 	
 	# Add line_wise flag if line wise motion
@@ -254,39 +297,47 @@ func call_cmd(cmd: Dictionary) -> Variant:
 	return cursor.call(func_name, cmd)
 
 
-static func get_event_char(event: InputEventKey) -> String:
+static func event_to_char(event: InputEventKey) -> String:
+	# Special chars
 	if event.keycode == KEY_ENTER:
 		return "<CR>"
 	if event.keycode == KEY_TAB:
 		return "<TAB>"
+	
+	# Ctrl + key
 	if event.is_command_or_control_pressed():
 		if !OS.is_keycode_unicode(event.keycode):
 			return ''
 		var c: String = char(event.keycode)
 		return "<C-%s>" % [ c if event.shift_pressed else c.to_lower() ]
+	
+	# You're not special.
 	return char(event.unicode)
 
 
-enum KeyMatch {
-	None = 0, # Keys don't match
-	Partial = 1, # Keys match partially
-	Absolute = 2, # Keys match totally
-}
-
-## Check whether keys [param a] is contained in keys [param b]
-static func match_keys(a: Array, b: Array) -> KeyMatch:
-	var partial: bool = false
-	
-	for i in mini(a.size(), b.size()):
-		if a[i] == b[i]:
-			partial = true
-			continue
+# Matches single command keys
+static func match_keys(expected_keys: Array, input_keys: Array) -> KeyMatch:
+	if expected_keys[-1] == "{char}":
+		# If everything + {char} matches
+		if input_keys.slice(0, -1) == expected_keys.slice(0, -1) and input_keys.size() == expected_keys.size():
+			return KeyMatch.Full
 		
-		# Partial if there was at least one match, else None
-		return KeyMatch.Partial * int(partial)
+		# If everything up until {char} matches
+		elif expected_keys.slice(0, input_keys.size()-1) == input_keys.slice(0, -1):
+			return KeyMatch.Partial
 	
-	return KeyMatch.Partial if b.size() < a.size() else KeyMatch.Absolute
-
+	else:
+		# Check for full match
+		if input_keys == expected_keys:
+			return KeyMatch.Full
+		# Check for incomplete command (e.g. "ge", "gcc")
+		elif expected_keys.slice(0, input_keys.size()) == input_keys:
+			return KeyMatch.Partial
+		# Cases with operators like "dj", "ce"
+		elif input_keys.slice(0, expected_keys.size()) == expected_keys and input_keys.size() > expected_keys.size():
+			return KeyMatch.Full
+		
+	return KeyMatch.None
 
 func clear():
 	input_stream = []

--- a/addons/godot_vim/plugin.gd
+++ b/addons/godot_vim/plugin.gd
@@ -162,3 +162,12 @@ func get_first_non_digit_idx(str: String) -> int:
 			return i
 	return -1 # All digits
 
+
+## Repeat the function `f` and accumulate the result. A bit like Array::reduce()
+## f: func(T) -> T  where T is the previous output
+func repeat_accum(count: int, inital_value: Variant, f: Callable) -> Variant:
+	var value: Variant = inital_value
+	for __ in count:
+		value = f.call(value)
+	return value
+

--- a/addons/godot_vim/plugin.gd
+++ b/addons/godot_vim/plugin.gd
@@ -1,11 +1,6 @@
 @tool
 extends EditorPlugin
 
-enum Mode { NORMAL, INSERT, VISUAL, VISUAL_LINE, COMMAND }
-
-# Used for commands like "w" "b" and "e" respectively
-enum WordEdgeMode { WORD, BEGINNING, END }
-
 const SPACES: String = " \t"
 const KEYWORDS: String = ".,\"'-=+!@#$%^&*()[]{}?~/\\<>:;"
 const DIGITS: String = "0123456789"


### PR DESCRIPTION
Semi-resolves #10

Implements `class KeyMap`:
This is where key presses are handled and prepared for execution.
The commands are executed in `cursor.gd` (See the "COMMANDS" section in the script - around line 350).
For example, the command for `{ "keys": [ ... ], "type": Motion, "motion": { "type": "foo", ... } }` would be handled in `cursor::cmd_foo(args: Dictionary)` where `args` is the `{ "type": "foo", ... }` inside `"motion"`.
Commands can be configured/changed in the const `KeyMap::key_map`.

Yet to be implemented:
- [ ] Repeating commands with `.`
- [ ] Marks (`m` and `)
- [ ] Word objects (e.g. `..iw`, `..ap`)