### PR TITLE
Insert mode key remap

### DIFF
--- a/addons/godot_vim/constants.gd
+++ b/addons/godot_vim/constants.gd
@@ -1,4 +1,10 @@
-enum Mode { NORMAL, INSERT, VISUAL, VISUAL_LINE, COMMAND }
+enum Mode {
+	NORMAL = 0,
+	INSERT,
+	VISUAL,
+	VISUAL_LINE,
+	COMMAND
+}
 
 # Used for commands like "w" "b" and "e" respectively
 enum WordEdgeMode { WORD, BEGINNING, END }

--- a/addons/godot_vim/constants.gd
+++ b/addons/godot_vim/constants.gd
@@ -6,10 +6,6 @@ enum Mode {
 	COMMAND
 }
 
-# Used for commands like "w" "b" and "e" respectively
-enum WordEdgeMode { WORD, BEGINNING, END }
-
-const SPACES: String = " \t"
-
 const KEYWORDS: String = ".,\"'-=+!@#$%^&*()[]{}?~/\\<>:;"
 const DIGITS: String = "0123456789"
+const SPACES: String = " \t"

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -1,39 +1,54 @@
 class_name KeyMap extends RefCounted
 ## Hanldes input stream and key mapping
+##
+## You may also set your keybindings in the [method map] function
 
-
-## SET YOUR KEYBINDINGS HERE
+## * SET YOUR KEYBINDINGS HERE *
 ## Also see the "COMMANDS" section at the bottom of cursor.gd
 ##  E.g. the command for
 ##    KeyRemap.new(...) .motion("foo", { "bar": 1 })
 ##  is handled in Cursor::cmd_foo(args: Dictionary)
 ##  where `args` is  `{ "type": "foo", "bar": 1 }`
+## Example:
+## [codeblock]
+## return [
+## 	# Move 5 characters to the right with "L"
+## 	KeyRemap.new([ "L" ])
+## 		.motion("move_by_chars", { "move_by": 5 }),
+## 	
+## 	# Make "q" the same as "d" (delete operator)
+## 	KeyRemap.new([ "q" ])
+## 		.operator("delete"),
+## 	
+## 	# Delete this line along with the next two with "Z"
+## 	# .operator() and .motion() automatically merge together
+## 	KeyRemap.new([ "Z" ])
+## 		.operator("delete")
+## 		.motion("move_by_lines", { "move_by": 2, "line_wise": true }),
+## 	
+## 	# In Insert mode, return to Normal mode with "Ctrl-["
+## 	KeyRemap.new([ "<C-[>" ])
+## 		.action("normal")
+## 		.with_context(Mode.INSERT),
+## 	
+## 	# In Insert mode, return to Normal mode with "jk"
+## 	KeyRemap.new([ "j", "k" ])
+## 		.action("normal", { "backspaces": 1, "offset": 1 })
+## 		.with_context(Mode.INSERT),
+## ]
+## [/codeblock]
 static func map() -> Array[KeyRemap]:
-	# Example set:
+	# Example:
 	return [
-		# Move 5 characters to the right with "L"
-		KeyRemap.new([ "L" ])
-			.motion("move_by_chars", { "move_by": 5 }),
-		
-		# Make "q" the same as "d" (delete operator)
-		KeyRemap.new([ "q" ])
-			.operator("delete"),
-		
-		# Delete this line along with the next two with "Z"
-		# .operator() and .motion() automatically merge together
-		KeyRemap.new([ "Z" ])
-			.operator("delete")
-			.motion("move_by_lines", { "move_by": 2, "line_wise": true }),
-		
-		# In Insert mode, return to Normal mode with "Ctrl-["
-		KeyRemap.new([ "<C-[>" ])
-			.action("normal")
-			.with_context(Mode.INSERT),
-		
 		# In Insert mode, return to Normal mode with "jk"
 		KeyRemap.new([ "j", "k" ])
 			.action("normal", { "backspaces": 1, "offset": 1 })
 			.with_context(Mode.INSERT),
+		
+		# In Insert mode, return to Normal mode with "Ctrl-["
+		# KeyRemap.new([ "<C-[>" ])
+			# .action("normal")
+			# .with_context(Mode.INSERT),
 	]
 
 

--- a/addons/godot_vim/plugin.gd
+++ b/addons/godot_vim/plugin.gd
@@ -21,6 +21,9 @@ func _enter_tree():
 	if get_code_edit() != null:
 		_load()
 	get_editor_interface().get_script_editor().connect("editor_script_changed", _script_changed)
+	
+	print("[Godot VIM] Initialized.")
+	print("    If you wish to set keybindings, please see the map() function in key_map.gd")
 
 func _script_changed(script: Script):
 	# Add to recent files

--- a/addons/godot_vim/remap.gd
+++ b/addons/godot_vim/remap.gd
@@ -1,0 +1,57 @@
+class_name KeyRemap extends RefCounted
+
+const Constants = preload("res://addons/godot_vim/constants.gd")
+const Mode = Constants.Mode
+
+var inner: Dictionary = {}
+
+# TODO allow the user to control the position of this remap inside `KeyMap.key_map`
+
+func _init(keys: Array[String]):
+	assert(!keys.is_empty(), "cmd_keys cannot be empty")
+	inner = { "keys": keys }
+
+
+## Returns self
+func motion(motion_type: String, args: Dictionary = {}) -> KeyRemap:
+	var m: Dictionary = { "type": motion_type }
+	m.merge(args, true)
+	inner.motion = m
+	
+	# Operator + Motion = OperatorMotion
+	if inner.get("type") == KeyMap.Operator:
+		inner.type = KeyMap.OperatorMotion
+	else:
+		inner.type = KeyMap.Motion
+	return self
+
+## Returns self
+func operator(operator_type: String, args: Dictionary = {}) -> KeyRemap:
+	var o: Dictionary = { "type": operator_type }
+	o.merge(args, true)
+	inner.operator = o
+	
+	# Motion + Operator = OperatorMotion
+	if inner.get("type") == KeyMap.Motion:
+		inner.type = KeyMap.OperatorMotion
+	else:
+		inner.type = KeyMap.Operator
+	return self
+
+## Returns self
+func action(action_type: String, args: Dictionary = {}) -> KeyRemap:
+	var a: Dictionary = { "type": action_type }
+	a.merge(args, true)
+	inner.action = a
+	inner.type = KeyMap.Action
+	return self
+
+
+## Returns self
+func with_context(mode: Mode) -> KeyRemap:
+	inner["context"] = mode
+	return self
+
+func as_dict() -> Dictionary:
+	return inner
+

--- a/readme.md
+++ b/readme.md
@@ -7,37 +7,27 @@ TO understand what each of the commands do, simply fire up a real instance of vi
 ## motion
 
 ```
-  h
-  j
-  k
-  l
-  w
-  e
-  b
-  f
-  t
+  h, j, k, l
+  w, e, ge, b
+  f, t, F, T
   ;
   ,
   $
   ^
   0
   gg
+  G
   }
   {
-  m
-  `
+  (Marks not yet implemented, please use Godot bookmarks)
 ```
 
 ## insert
 
 ```
-  i
-  I
-  a
-  A
-  G
-  o
-  O
+  i I
+  a A
+  o O
 ```
 
 ## visual
@@ -80,24 +70,13 @@ TO understand what each of the commands do, simply fire up a real instance of vi
 
 ```
   J
-  d
-  dd
-  D
+  d dd D
   p
-  P
   x
   s
   r
-  y
-  yy
-  n
-  N
-  c
-  c
-  C
-  z
-  >
-  >>
-  <
-  <<
+  y yy
+  c cc C
+  > >>
+  < <<
 ```


### PR DESCRIPTION
resolves #13 

- Adds documentation comments to cmds in `cursor.gd`
- Adds code to allow keybinds in `INSERT` mode
- Adds `KeyRemap (remap.gd)` for easier remapping of keybinds
- Adds the `map()` function to `KeyMap (key_map.gd)` where keybinds can be added
Usage example:
```gdscript
# key_map.gd
static func map() -> Array[KeyRemap]:
    return [
        # Move 5 characters to the right with "L"
        KeyRemap.new([ "L" ])
            .motion("move_by_chars", { "move_by": 5 }),

        # Make "q" the same as "d" (delete operator)
        KeyRemap.new([ "q" ])
            .operator("delete"),

        # Delete this line along with the next two with "Z"
        # .operator() and .motion() automatically merge together
        KeyRemap.new([ "Z" ])
            .operator("delete")
            .motion("move_by_lines", { "move_by": 2, "line_wise": true }),

        # In Insert mode, return to Normal mode with "jk"
        KeyRemap.new([ "j", "k" ])
            .action("normal", { "backspaces": 1, "offset": 1 })
            .with_context(Mode.INSERT),

        # In Insert mode, return to Normal mode with "Ctrl-["
        KeyRemap.new([ "<C-[>" ])
            .action("normal")
            .with_context(Mode.INSERT),
    ]
```