### PR TITLE
Fix typos in variable names

### DIFF
--- a/addons/godot_vim/commands/delmarks.gd
+++ b/addons/godot_vim/commands/delmarks.gd
@@ -1,6 +1,6 @@
-const Contants = preload("res://addons/godot_vim/constants.gd")
+const Constants = preload("res://addons/godot_vim/constants.gd")
 const StatusBar = preload("res://addons/godot_vim/status_bar.gd")
-const Mode = Contants.Mode
+const Mode = Constants.Mode
 
 const LINE_START_IDX: int = 8
 const COL_START_IDX: int = 16

--- a/addons/godot_vim/commands/marks.gd
+++ b/addons/godot_vim/commands/marks.gd
@@ -1,6 +1,6 @@
-const Contants = preload("res://addons/godot_vim/constants.gd")
+const Constants = preload("res://addons/godot_vim/constants.gd")
 const StatusBar = preload("res://addons/godot_vim/status_bar.gd")
-const Mode = Contants.Mode
+const Mode = Constants.Mode
 
 const LINE_START_IDX: int = 8
 const COL_START_IDX: int = 16

--- a/addons/godot_vim/commands/remap.gd
+++ b/addons/godot_vim/commands/remap.gd
@@ -1,6 +1,6 @@
-const Contants = preload("res://addons/godot_vim/constants.gd")
+const Constants = preload("res://addons/godot_vim/constants.gd")
 const StatusBar = preload("res://addons/godot_vim/status_bar.gd")
-const Mode = Contants.Mode
+const Mode = Constants.Mode
 
 func execute(api: Dictionary, _args):
 	print("[Godot VIM] Please run :reload in the command line after changing your keybinds")


### PR DESCRIPTION
Some variables were named "Contants" instead of "Constants" in some of the files.