### PR TITLE
Add "w" and "wa" commands

### DIFF
--- a/addons/godot_vim/commands/w.gd
+++ b/addons/godot_vim/commands/w.gd
@@ -1,0 +1,16 @@
+const Constants = preload("res://addons/godot_vim/constants.gd")
+const Mode = Constants.Mode
+
+func execute(api, args: String):
+	#EditorInterface.save_scene()
+	press_save_shortcut()
+	api.cursor.set_mode(Mode.NORMAL)
+
+func press_save_shortcut():
+	var a = InputEventKey.new()
+	a.keycode = KEY_S
+	a.ctrl_pressed = true
+	a.alt_pressed = true
+	a.pressed = true
+	Input.parse_input_event(a)
+	pass

--- a/addons/godot_vim/commands/wa.gd
+++ b/addons/godot_vim/commands/wa.gd
@@ -1,0 +1,16 @@
+const Constants = preload("res://addons/godot_vim/constants.gd")
+const Mode = Constants.Mode
+
+func execute(api, args: String):
+	#EditorInterface.save_scene()
+	press_save_shortcut()
+	api.cursor.set_mode(Mode.NORMAL)
+
+func press_save_shortcut():
+	var a = InputEventKey.new()
+	a.keycode = KEY_S
+	a.shift_pressed = true
+	a.alt_pressed = true
+	a.pressed = true
+	Input.parse_input_event(a)
+	pass

--- a/addons/godot_vim/dispatcher.gd
+++ b/addons/godot_vim/dispatcher.gd
@@ -7,6 +7,8 @@ var handlers: Dictionary = {
 	"delmarks": preload("res://addons/godot_vim/commands/delmarks.gd"),
 	"moveline": preload("res://addons/godot_vim/commands/moveline.gd"),
 	"movecolumn": preload("res://addons/godot_vim/commands/movecolumn.gd"),
+	"w": preload("res://addons/godot_vim/commands/w.gd"),
+	"wa": preload("res://addons/godot_vim/commands/wa.gd"),
 	
 	# GodotVIM speficic commands:
 	"reload": preload("res://addons/godot_vim/commands/reload.gd"),


### PR DESCRIPTION
Simulates pressing "ctrl+alt+s" with ":w" is entered into the command line, and "shift+alt+s" when ":wa" is entered, saving the current script and all scripts respectively.