### PR TITLE
Text objects

### DIFF
--- a/addons/godot_vim/command_line.gd
+++ b/addons/godot_vim/command_line.gd
@@ -46,7 +46,11 @@ func _on_text_changed(cmd: String):
 	if code_edit.get_caret_count() < 2:
 		code_edit.add_caret(pos.y, pos.x)
 	code_edit.select(pos.y, pos.x, pos.y, pos.x + rmatch.get_string().length(), 1)
-	code_edit.scroll_vertical = code_edit.get_scroll_pos_for_line(pos.y)
+	# code_edit.center_viewport_to_caret(1) # why no work, eh?
+	
+	code_edit.scroll_vertical = code_edit.get_scroll_pos_for_line(pos.y)\
+		# Offset to center
+		- code_edit.get_visible_line_count() / 2
 
 func handle_command(cmd: String):
 	if cmd.begins_with('/'):

--- a/addons/godot_vim/commands/find.gd
+++ b/addons/godot_vim/commands/find.gd
@@ -11,6 +11,7 @@ func execute(api : Dictionary, args: String):
 	if rmatch != null:
 		var pos: Vector2i = api.vim_plugin.idx_to_pos(api.code_edit, rmatch.get_start())
 		api.cursor.set_caret_pos(pos.y, pos.x)
+		# api.code_edit.center_viewport_to_caret()
 	else:
 		api.status_bar.display_error('Pattern not found: "%s"' % [api.command_line.search_pattern])
 	api.cursor.set_mode(Mode.NORMAL)

--- a/addons/godot_vim/constants.gd
+++ b/addons/godot_vim/constants.gd
@@ -11,6 +11,18 @@ enum Language {
 	SHADER,
 }
 
-const KEYWORDS: String = ".,\"'-=+!@#$%^&*()[]{}?~/\\<>:;"
+const KEYWORDS: String = ".,\"'-=+!@#$%^&*()[]{}?~/\\<>:;`"
 const DIGITS: String = "0123456789"
 const SPACES: String = " \t"
+const BRACES: Dictionary = {
+	'"': '"',
+	"'": "'",
+	"`": "`",
+	"(": ")",
+	"[": "]",
+	"{": "}",
+}
+## Braces we want to keep inline
+## See cursor.gd::cmd_text_object()
+const INLINE_BRACES: Array[String] = [ '"', "'", "`", ]
+

--- a/addons/godot_vim/constants.gd
+++ b/addons/godot_vim/constants.gd
@@ -14,7 +14,7 @@ enum Language {
 const KEYWORDS: String = ".,\"'-=+!@#$%^&*()[]{}?~/\\<>:;`"
 const DIGITS: String = "0123456789"
 const SPACES: String = " \t"
-const BRACES: Dictionary = {
+const PAIRS: Dictionary = {
 	'"': '"',
 	"'": "'",
 	"`": "`",
@@ -22,4 +22,5 @@ const BRACES: Dictionary = {
 	"[": "]",
 	"{": "}",
 }
+const BRACES: String = "([{}])"
 

--- a/addons/godot_vim/constants.gd
+++ b/addons/godot_vim/constants.gd
@@ -22,7 +22,4 @@ const BRACES: Dictionary = {
 	"[": "]",
 	"{": "}",
 }
-## Braces we want to keep inline
-## See cursor.gd::cmd_text_object()
-const INLINE_BRACES: Array[String] = [ '"', "'", "`", ]
 

--- a/addons/godot_vim/cursor.gd
+++ b/addons/godot_vim/cursor.gd
@@ -529,14 +529,33 @@ func cmd_move_by_section(args: Dictionary) -> Vector2i:
 #region TEXT OBJECTS
 # Text Object commands must return two Vector2is with the cursor start and end position
 
-## TODO "aw" word object
+## TODO "aw" word object ("inner" = false). See `var key_map` in KeyMap
 func cmd_text_object_word(args: Dictionary) -> Array[Vector2i]:
 	# print("[cmd_text_object_word()] args = ", args)
-	var p: Vector2i = get_caret_pos()
-	var p0: Vector2i = get_word_edge_pos(p.y, p.x + 1, false, false, false)
-	var p1: Vector2i = get_word_edge_pos(p.y, p.x - 1, true, true, false)
+	var is_big_word: bool = args.get("big_word", false)
 	
-	return [ p0, p1 ]
+	var p: Vector2i = get_caret_pos()
+	return [
+		get_word_edge_pos(p.y, p.x + 1, false, false, is_big_word),
+		get_word_edge_pos(p.y, p.x - 1, true, true, is_big_word)
+	]
+
+## TODO "ap" word object ("inner" = false). See `var key_map` in KeyMap
+## Warning: changes the current mode to VISUAL_LINE if in VISUAL
+func cmd_text_object_paragraph(args: Dictionary) -> Array[Vector2i]:
+	# print("[cmd_text_object_paragraph()] args = ", args)
+	
+	var p: Vector2i = get_caret_pos()
+	var p0: Vector2i = get_paragraph_edge_pos(p.y, false)
+	var p1: Vector2i = get_paragraph_edge_pos(p.y, true)
+	
+	if mode == Mode.VISUAL:
+		set_mode(Mode.VISUAL_LINE)
+	
+	return [
+		p0 + Vector2i.DOWN,
+		p1 + Vector2i.UP
+	]
 
 #endregion TEXT OBJECTS
 

--- a/addons/godot_vim/cursor.gd
+++ b/addons/godot_vim/cursor.gd
@@ -70,6 +70,7 @@ func _input(event: InputEvent):
 	
 	if KeyMap.is_cmd_valid(registered_cmd):
 		code_edit.cancel_code_completion()
+		get_viewport().set_input_as_handled()
 
 
 ## TODO Old commands we are yet to move (delete as they get implemented)
@@ -217,11 +218,13 @@ func set_mode(m: int):
 			if old_mode != Mode.VISUAL_LINE:
 				selection_from = Vector2i(code_edit.get_caret_column(), code_edit.get_caret_line())
 			status_bar.set_mode_text(Mode.VISUAL)
+			update_visual_selection()
 		
 		Mode.VISUAL_LINE:
 			if old_mode != Mode.VISUAL:
 				selection_from = Vector2i(code_edit.get_caret_column(), code_edit.get_caret_line())
 			status_bar.set_mode_text(Mode.VISUAL_LINE)
+			update_visual_selection()
 		
 		Mode.COMMAND:
 			command_line.show()
@@ -749,13 +752,14 @@ func cmd_change(args: Dictionary):
 
 func cmd_paste(_args: Dictionary):
 	code_edit.begin_complex_operation()
-	if is_mode_visual(mode):
-		code_edit.delete_selection()
-	if DisplayServer.clipboard_get().begins_with('\r\n'):
-		set_column(get_line_length())
-	else:
-		move_column(+1)
-	code_edit.deselect()
+	
+	if !is_mode_visual(mode):
+		if DisplayServer.clipboard_get().begins_with('\r\n'):
+			set_column(get_line_length())
+		else:
+			move_column(+1)
+		code_edit.deselect()
+	
 	code_edit.paste()
 	move_column(-1)
 	code_edit.end_complex_operation()

--- a/addons/godot_vim/cursor.gd
+++ b/addons/godot_vim/cursor.gd
@@ -342,6 +342,12 @@ func get_line_text(line: int = -1) -> String:
 		return code_edit.get_line(get_line())
 	return code_edit.get_line(line)
 
+func get_char_at(line: int, col: int) -> String:
+	var text: String = code_edit.get_line(line)
+	if col > 0 and col < text.length():
+		return text[col]
+	return ""
+
 func get_line_length(line: int = -1) -> int:
 	return get_line_text(line).length()
 
@@ -404,6 +410,7 @@ func is_line_section(text: String) -> bool:
 			return t.ends_with("{") and !SPACES.contains(text.left(1))
 		LANGUAGE.GDSCRIPT:
 			return t.begins_with("func")\
+				or t.begins_with("static func")\
 				or t.begins_with("class")\
 				or t.begins_with("#region")
 		_:
@@ -686,7 +693,7 @@ func cmd_text_object(args: Dictionary) -> Array[Vector2i]:
 	var inline: bool = args.get("inline", false)
 	
 	# Deal with edge case where the cursor is already on the end
-	var p0x = p.x - 1 if get_line_text(p.y)[p.x] == counterpart else p.x
+	var p0x = p.x - 1 if get_char_at(p.y, p.x) == counterpart else p.x
 	# Look backwards to find start
 	var p0: Vector2i = find_brace(
 		p.y,

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -203,12 +203,16 @@ var key_map: Array[Dictionary] = [
 	{ "keys": ["z", "z"], "type": Action, "action": { "type": "center_caret" } },
 	{ "keys": ["m", "{char}"], "type": Action, "action": { "type": "mark" } },
 	{ "keys": ["`", "{char}"], "type": Action, "action": { "type": "jump_to_mark" } },
+	
+	# MISCELLANEOUS
+	{ "keys": ["o"], "type": Operator, "context": Mode.VISUAL, "operator": { "type": "visual_jump_to_other_end" } },
+	{ "keys": ["o"], "type": Operator, "context": Mode.VISUAL_LINE, "operator": { "type": "visual_jump_to_other_end" } },
 ]
 
 # Keys we won't handle
 const BLACKLIST: Array[String] = [
 	"<C-s>", # Save
-	"<C-b>", # Bookmark (marks arent' implemented yet)
+	"<C-b>", # Bookmark
 ]
 
 enum KeyMatch {

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -138,9 +138,9 @@ var key_map: Array[Dictionary] = [
 	{ "keys": ["a", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": false, "line_wise": true } }, # TODO
 	{ "keys": ["i", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": true, "line_wise": true } },
 	
-	{ "keys": ["i", "\""], "type": Motion, "motion": { "type": "text_object", "object": "\"", "inner": true, "inclusive": true } },
-	{ "keys": ["i", "'"], "type": Motion, "motion": { "type": "text_object", "object": "'", "inner": true, "inclusive": true } },
-	{ "keys": ["i", "`"], "type": Motion, "motion": { "type": "text_object", "object": "`", "inner": true, "inclusive": true } },
+	{ "keys": ["i", "\""], "type": Motion, "motion": { "type": "text_object", "object": "\"", "inner": true, "inclusive": true, "inline": true } },
+	{ "keys": ["i", "'"], "type": Motion, "motion": { "type": "text_object", "object": "'", "inner": true, "inclusive": true, "inline": true } },
+	{ "keys": ["i", "`"], "type": Motion, "motion": { "type": "text_object", "object": "`", "inner": true, "inclusive": true, "inline": true } },
 	{ "keys": ["i", "("], "type": Motion, "motion": { "type": "text_object", "object": "(", "inner": true, "inclusive": true } },
 	{ "keys": ["i", "b"], "type": Motion, "motion": { "type": "text_object", "object": "(", "inner": true, "inclusive": true } },
 	{ "keys": ["i", "["], "type": Motion, "motion": { "type": "text_object", "object": "[", "inner": true, "inclusive": true } },

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -129,16 +129,17 @@ var key_map: Array[Dictionary] = [
 	{ "keys": ["g", "m"], "type": Motion, "motion": { "type": "move_to_center_of_line" } },
 	{ "keys": ["<C-u>"], "type": Motion, "motion": { "type": "move_by_screen", "percentage": -0.5, "line_wise": true } },
 	{ "keys": ["<C-d>"], "type": Motion, "motion": { "type": "move_by_screen", "percentage": 0.5, "line_wise": true } },
-	{ "keys": ["%"], "type": Motion, "motion": { "type": "jump_to_next_brace_pair" } }, # TODO
+	{ "keys": ["%"], "type": Motion, "motion": { "type": "jump_to_next_brace_pair" } },
 	
 	# TEXT OBJECTS
-	{ "keys": ["a", "w"], "type": Motion, "motion": { "type": "text_object_word", "inner": false, "inclusive": false } }, # TODO
-	{ "keys": ["a", "W"], "type": Motion, "motion": { "type": "text_object_word", "inner": false, "inclusive": false } }, # TODO
-	{ "keys": ["i", "w"], "type": Motion, "motion": { "type": "text_object_word", "inner": true, "inclusive": true } },
-	{ "keys": ["i", "W"], "type": Motion, "motion": { "type": "text_object_word", "inner": true, "big_word": true, "inclusive": true } },
-	{ "keys": ["i", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": true, "line_wise": true } },
-	{ "keys": ["a", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": false, "line_wise": true } }, # TODO
+	{ "keys": ["a", "w"], "type": Motion, "motion": { "type": "text_object_word", "around": true, "inclusive": true } },
+	{ "keys": ["a", "W"], "type": Motion, "motion": { "type": "text_object_word", "around": true, "inclusive": true } },
+	{ "keys": ["i", "w"], "type": Motion, "motion": { "type": "text_object_word", "inclusive": true } },
+	{ "keys": ["i", "W"], "type": Motion, "motion": { "type": "text_object_word", "big_word": true, "inclusive": true } },
+	{ "keys": ["i", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "line_wise": true } },
+	{ "keys": ["a", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "around": true, "line_wise": true } },
 	
+	# TODO around text objects for these
 	{ "keys": ["i", "\""], "type": Motion, "motion": { "type": "text_object", "object": "\"", "inner": true, "inclusive": true, "inline": true } },
 	{ "keys": ["i", "'"], "type": Motion, "motion": { "type": "text_object", "object": "'", "inner": true, "inclusive": true, "inline": true } },
 	{ "keys": ["i", "`"], "type": Motion, "motion": { "type": "text_object", "object": "`", "inner": true, "inclusive": true, "inline": true } },

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -278,7 +278,7 @@ func parse_keys(keys: Array[String], with_context: Mode) -> Dictionary:
 	return cmd
 
 ## The returned cmd will always have a 'type' key
-# TODO make bitmask
+# TODO use bitmask instead of Array
 func find_cmd(keys: Array[String], with_context: Mode, blacklist: Array = []) -> Dictionary:
 	var partial: bool = false # In case none were found
 	var is_visual: bool = with_context == Mode.VISUAL or with_context == Mode.VISUAL_LINE
@@ -291,14 +291,6 @@ func find_cmd(keys: Array[String], with_context: Mode, blacklist: Array = []) ->
 		
 		if blacklist.has(cmd.type):
 			continue
-		
-		""" TODO delete
-		# Allow Operators to be executed as-is (without additional motion) in visual mode
-		if !(cmd.type == Operator and is_visual):
-			# Check context for other commands
-			if cmd.has("context") and with_context != cmd.context:
-				continue
-		"""
 		
 		# Skip if contexts don't match
 		if cmd.has("context") and with_context != cmd.context:
@@ -320,54 +312,8 @@ func find_cmd(keys: Array[String], with_context: Mode, blacklist: Array = []) ->
 	
 	return { "type": Incomplete if partial else NotFound }
 
-""" Old find_cmd	TODO delete
 
-## The returned cmd will always have a 'type' key
-# TODO make bitmask
-func find_cmd(keys: Array[String], with_context: Mode) -> Dictionary:
-	var partial: bool = false # In case none were found
-	var is_visual: bool = with_context == Mode.VISUAL or with_context == Mode.VISUAL_LINE
-	
-	for cmd in key_map:
-		# FILTERS
-		# Don't allow anything in Insert mode unless specified
-		if with_context == Mode.INSERT and cmd.get("context", -1) != Mode.INSERT:
-			continue
-		
-		# OperatorMotions in visual mode aren't allowed
-		if cmd.type == OperatorMotion and is_visual:
-			continue
-		
-		# Don't allow Actions in Visual mode unless specified
-		if cmd.type == Action and is_visual\
-			and !(cmd.has("context") and cursor.is_mode_visual(cmd.context)):
-			continue
-		
-		# Allow Operators to be executed as-is (without additional motion) in visual mode
-		if !(cmd.type == Operator and is_visual):
-			# Check context for other commands
-			if cmd.has("context") and with_context != cmd.context:
-				continue
-		
-		# CHECK KEYS
-		var m: KeyMatch = match_keys(cmd.keys, keys)
-		partial = partial or m == KeyMatch.Partial # Set/keep partial = true if it was a partial match
-		
-		if m != KeyMatch.Full:
-			continue
-		
-		var cmd_mut: Dictionary = cmd.duplicate(true) # 'mut' ('mutable') because key_map is read-only
-		# Keep track of selected character, which will later be copied into the fucntion call for the command
-		# (See execute() where we check if cmd.has('selected_char'))
-		if cmd.keys[-1] == '{char}':
-			cmd_mut.selected_char = keys.back()
-		return cmd_mut
-	
-	return { "type": Incomplete if partial else NotFound }
-"""
-
-
-# TODO make bitmask instead of Array
+# TODO use bitmask instead of Array
 func get_blacklist_types_in_context(context: Mode) -> Array:
 	match context:
 		Mode.VISUAL, Mode.VISUAL_LINE:

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -41,14 +41,14 @@ static func map() -> Array[KeyRemap]:
 	# Example:
 	return [
 		# In Insert mode, return to Normal mode with "jk"
-		KeyRemap.new([ "j", "i" ])
-			.action("normal", { "backspaces": 1, "offset": 0 })
-			.with_context(Mode.INSERT),
+		# KeyRemap.new([ "j", "k" ])
+			# .action("normal", { "backspaces": 1, "offset": 0 })
+			# .with_context(Mode.INSERT),
 		
 		# Make "/" search in case insensitive mode
-		KeyRemap.new([ "/" ])
-			.action("command", { "command": "/(?i)" })
-			.replace(),
+		# KeyRemap.new([ "/" ])
+			# .action("command", { "command": "/(?i)" })
+			# .replace(),
 		
 		# In Insert mode, return to Normal mode with "Ctrl-["
 		# KeyRemap.new([ "<C-[>" ])
@@ -139,14 +139,19 @@ var key_map: Array[Dictionary] = [
 	{ "keys": ["i", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "line_wise": true } },
 	{ "keys": ["a", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "around": true, "line_wise": true } },
 	
-	# TODO "around" text objects for these
-	{ "keys": ["i", "\""], "type": Motion, "motion": { "type": "text_object", "object": "\"", "inner": true, "inclusive": true, "inline": true } },
-	{ "keys": ["i", "'"], "type": Motion, "motion": { "type": "text_object", "object": "'", "inner": true, "inclusive": true, "inline": true } },
-	{ "keys": ["i", "`"], "type": Motion, "motion": { "type": "text_object", "object": "`", "inner": true, "inclusive": true, "inline": true } },
+	{ "keys": ["i", "\""], "type": Motion, "motion": { "type": "text_object", "object": "\"", "inclusive": true, "inline": true } },
+	{ "keys": ["a", "\""], "type": Motion, "motion": { "type": "text_object", "object": "\"", "around": true, "inclusive": true, "inline": true } },
+	{ "keys": ["i", "'"], "type": Motion, "motion": { "type": "text_object", "object": "'", "inclusive": true, "inline": true } },
+	{ "keys": ["a", "'"], "type": Motion, "motion": { "type": "text_object", "object": "'", "around": true, "inclusive": true, "inline": true } },
+	{ "keys": ["i", "`"], "type": Motion, "motion": { "type": "text_object", "object": "`", "inclusive": true, "inline": true } },
+	{ "keys": ["a", "`"], "type": Motion, "motion": { "type": "text_object", "object": "`", "around": true, "inclusive": true, "inline": true } },
 	# "i" + any of "(", ")", or "b"
-	{ "keys": ["i", ["(", ")", "b"]], "type": Motion, "motion": { "type": "text_object", "object": "(", "inner": true, "inclusive": true } },
-	{ "keys": ["i", ["[", "]"]], "type": Motion, "motion": { "type": "text_object", "object": "[", "inner": true, "inclusive": true } },
-	{ "keys": ["i", ["{", "}", "B"]], "type": Motion, "motion": { "type": "text_object", "object": "{", "inner": true, "inclusive": true } },
+	{ "keys": ["i", ["(", ")", "b"]], "type": Motion, "motion": { "type": "text_object", "object": "(", "inclusive": true } },
+	{ "keys": ["a", ["(", ")", "b"]], "type": Motion, "motion": { "type": "text_object", "object": "(", "around": true, "inclusive": true } },
+	{ "keys": ["i", ["[", "]"]], "type": Motion, "motion": { "type": "text_object", "object": "[", "inclusive": true } },
+	{ "keys": ["a", ["[", "]"]], "type": Motion, "motion": { "type": "text_object", "object": "[", "around": true, "inclusive": true } },
+	{ "keys": ["i", ["{", "}", "B"]], "type": Motion, "motion": { "type": "text_object", "object": "{", "inclusive": true } },
+	{ "keys": ["a", ["{", "}", "B"]], "type": Motion, "motion": { "type": "text_object", "object": "{", "around": true, "inclusive": true } },
 	
 	# OPERATORS
 	{ "keys": ["d"], "type": Operator, "operator": { "type": "delete" } },

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -126,11 +126,11 @@ var key_map: Array[Dictionary] = [
 	{ "keys": ["N"], "type": Motion, "motion": { "type": "find_again", "forward": false } },
 	
 	# TEXT OBJECTS
-	# { "keys": ["a", "w"], "type": Motion, "motion": { "type": "text_object_word", "inner": false, "inclusive": false } }, # TODO
-	# { "keys": ["a", "W"], "type": Motion, "motion": { "type": "text_object_word", "inner": false, "inclusive": false } }, # TODO
+	{ "keys": ["a", "w"], "type": Motion, "motion": { "type": "text_object_word", "inner": false, "inclusive": false } }, # TODO
+	{ "keys": ["a", "W"], "type": Motion, "motion": { "type": "text_object_word", "inner": false, "inclusive": false } }, # TODO
 	{ "keys": ["i", "w"], "type": Motion, "motion": { "type": "text_object_word", "inner": true, "inclusive": true } },
 	{ "keys": ["i", "W"], "type": Motion, "motion": { "type": "text_object_word", "inner": true, "big_word": true, "inclusive": true } },
-	# { "keys": ["a", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": false, "line_wise": true } }, # TODO
+	{ "keys": ["a", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": false, "line_wise": true } }, # TODO
 	{ "keys": ["i", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": true, "line_wise": true } },
 	
 	# OPERATORS
@@ -182,6 +182,8 @@ var key_map: Array[Dictionary] = [
 	{ "keys": ["~"], "type": Operator, "context": Mode.VISUAL, "operator": { "type": "toggle_uppercase" } },
 	{ "keys": ["u"], "type": Operator, "context": Mode.VISUAL, "operator": { "type": "set_uppercase", "uppercase": false } },
 	{ "keys": ["U"], "type": Operator, "context": Mode.VISUAL, "operator": { "type": "set_uppercase", "uppercase": true } },
+	{ "keys": ["V"], "type": Operator, "context": Mode.VISUAL, "operator": { "type": "visual", "line_wise": true } },
+	{ "keys": ["v"], "type": Operator, "context": Mode.VISUAL_LINE, "operator": { "type": "visual", "line_wise": false } },
 	
 	# ACTIONS
 	{ "keys": ["i"], "type": Action, "action": { "type": "insert" } },
@@ -366,6 +368,7 @@ func execute_motion(cmd: Dictionary):
 	if pos is Vector2i:
 		cursor.set_caret_pos(pos.y, pos.x)
 	elif pos is Array:
+		assert(pos.size() == 2)
 		# print("[execute_motion() -> text obj] pos = ", pos)
 		cursor.select(pos[0].y, pos[0].x, pos[1].y, pos[1].x)
 
@@ -397,9 +400,8 @@ func operator_motion(operator: Dictionary, motion: Dictionary):
 			p.x += 1
 		cursor.code_edit.select(p0.y, p0.x, p.y, p.x)
 	elif p is Array:
-		# FIXME what to do if motion.inclusive?
+		assert(p.size() == 2)
 		if motion.get('inclusive', false):
-			print('a')
 			p[1].x += 1
 		cursor.code_edit.select(p[0].y, p[0].x, p[1].y, p[1].x)
 	

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -166,6 +166,7 @@ var key_map: Array[Dictionary] = [
 		"motion": { "type": "move_by_chars", "move_by": 1 }
 	},
 	{ "keys": ["p"], "type": Operator, "context": Mode.VISUAL, "operator": { "type": "paste" } },
+	{ "keys": ["p"], "type": Operator, "context": Mode.VISUAL_LINE, "operator": { "type": "paste" } },
 	
 	{ "keys": [">"], "type": Operator, "operator": { "type": "indent", "forward": true } },
 	{ "keys": ["<"], "type": Operator, "operator": { "type": "indent", "forward": false } },

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -85,6 +85,8 @@ enum {
 
 
 
+#region key_map
+
 # Also see the "COMMANDS" section at the bottom of cursor.gd
 #  Command for     { "type": "foo", ... }   is handled in Cursor::cmd_foo(args: Dictionary)
 #  where `args` is ^^^^^ this Dict ^^^^^^
@@ -105,12 +107,15 @@ var key_map: Array[Dictionary] = [
 	{ "keys": ["B"], "type": Motion, "motion": { "type": "move_by_word", "forward": false, "word_end": false, "big_word": true } },
 	{ "keys": ["g", "E"], "type": Motion, "motion": { "type": "move_by_word", "forward": false, "word_end": true, "big_word": true } },
 	
+	# Find & search
 	{ "keys": ["f", "{char}"], "type": Motion, "motion": { "type": "find_in_line", "forward": true, "inclusive": true } },
 	{ "keys": ["t", "{char}"], "type": Motion, "motion": { "type": "find_in_line", "forward": true, "stop_before": true, "inclusive": true } },
 	{ "keys": ["F", "{char}"], "type": Motion, "motion": { "type": "find_in_line", "forward": false } },
 	{ "keys": ["T", "{char}"], "type": Motion, "motion": { "type": "find_in_line", "forward": false, "stop_before": true } },
 	{ "keys": [";"], "type": Motion, "motion": { "type": "find_in_line_again", "invert": false } },
 	{ "keys": [","], "type": Motion, "motion": { "type": "find_in_line_again", "invert": true } },
+	{ "keys": ["n"], "type": Motion, "motion": { "type": "find_again", "forward": true } },
+	{ "keys": ["N"], "type": Motion, "motion": { "type": "find_again", "forward": false } },
 	
 	{ "keys": ["0"], "type": Motion, "motion": { "type": "move_to_bol" } },
 	{ "keys": ["$"], "type": Motion, "motion": { "type": "move_to_eol" } },
@@ -122,8 +127,8 @@ var key_map: Array[Dictionary] = [
 	{ "keys": ["g", "g"], "type": Motion, "motion": { "type": "move_to_bof", "line_wise": true } },
 	{ "keys": ["G"], "type": Motion, "motion": { "type": "move_to_eof", "line_wise": true } },
 	{ "keys": ["g", "m"], "type": Motion, "motion": { "type": "move_to_center_of_line" } },
-	{ "keys": ["n"], "type": Motion, "motion": { "type": "find_again", "forward": true } },
-	{ "keys": ["N"], "type": Motion, "motion": { "type": "find_again", "forward": false } },
+	{ "keys": ["<C-u>"], "type": Motion, "motion": { "type": "move_by_screen", "percentage": -0.5, "line_wise": true } },
+	{ "keys": ["<C-d>"], "type": Motion, "motion": { "type": "move_by_screen", "percentage": 0.5, "line_wise": true } },
 	
 	# TEXT OBJECTS
 	{ "keys": ["a", "w"], "type": Motion, "motion": { "type": "text_object_word", "inner": false, "inclusive": false } }, # TODO
@@ -132,6 +137,15 @@ var key_map: Array[Dictionary] = [
 	{ "keys": ["i", "W"], "type": Motion, "motion": { "type": "text_object_word", "inner": true, "big_word": true, "inclusive": true } },
 	{ "keys": ["a", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": false, "line_wise": true } }, # TODO
 	{ "keys": ["i", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": true, "line_wise": true } },
+	
+	{ "keys": ["i", "\""], "type": Motion, "motion": { "type": "text_object", "object": "\"", "inner": true, "inclusive": true } },
+	{ "keys": ["i", "'"], "type": Motion, "motion": { "type": "text_object", "object": "'", "inner": true, "inclusive": true } },
+	{ "keys": ["i", "`"], "type": Motion, "motion": { "type": "text_object", "object": "`", "inner": true, "inclusive": true } },
+	{ "keys": ["i", "("], "type": Motion, "motion": { "type": "text_object", "object": "(", "inner": true, "inclusive": true } },
+	{ "keys": ["i", "b"], "type": Motion, "motion": { "type": "text_object", "object": "(", "inner": true, "inclusive": true } },
+	{ "keys": ["i", "["], "type": Motion, "motion": { "type": "text_object", "object": "[", "inner": true, "inclusive": true } },
+	{ "keys": ["i", "{"], "type": Motion, "motion": { "type": "text_object", "object": "{", "inner": true, "inclusive": true } },
+	{ "keys": ["i", "B"], "type": Motion, "motion": { "type": "text_object", "object": "{", "inner": true, "inclusive": true } },
 	
 	# OPERATORS
 	{ "keys": ["d"], "type": Operator, "operator": { "type": "delete" } },
@@ -209,6 +223,9 @@ var key_map: Array[Dictionary] = [
 	{ "keys": ["o"], "type": Operator, "context": Mode.VISUAL, "operator": { "type": "visual_jump_to_other_end" } },
 	{ "keys": ["o"], "type": Operator, "context": Mode.VISUAL_LINE, "operator": { "type": "visual_jump_to_other_end" } },
 ]
+
+#endregion key_map
+
 
 # Keys we won't handle
 const BLACKLIST: Array[String] = [
@@ -289,7 +306,7 @@ func parse_keys(keys: Array[String], with_context: Mode) -> Dictionary:
 	return cmd
 
 ## The returned cmd will always have a 'type' key
-# TODO use bitmask instead of Array
+# TODO use bitmask instead of Array?
 func find_cmd(keys: Array[String], with_context: Mode, blacklist: Array = []) -> Dictionary:
 	var partial: bool = false # In case none were found
 	var is_visual: bool = with_context == Mode.VISUAL or with_context == Mode.VISUAL_LINE
@@ -324,7 +341,7 @@ func find_cmd(keys: Array[String], with_context: Mode, blacklist: Array = []) ->
 	return { "type": Incomplete if partial else NotFound }
 
 
-# TODO use bitmask instead of Array
+# TODO use bitmask instead of Array?
 func get_blacklist_types_in_context(context: Mode) -> Array:
 	match context:
 		Mode.VISUAL, Mode.VISUAL_LINE:

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -129,22 +129,26 @@ var key_map: Array[Dictionary] = [
 	{ "keys": ["g", "m"], "type": Motion, "motion": { "type": "move_to_center_of_line" } },
 	{ "keys": ["<C-u>"], "type": Motion, "motion": { "type": "move_by_screen", "percentage": -0.5, "line_wise": true } },
 	{ "keys": ["<C-d>"], "type": Motion, "motion": { "type": "move_by_screen", "percentage": 0.5, "line_wise": true } },
+	{ "keys": ["%"], "type": Motion, "motion": { "type": "jump_to_next_brace_pair" } }, # TODO
 	
 	# TEXT OBJECTS
 	{ "keys": ["a", "w"], "type": Motion, "motion": { "type": "text_object_word", "inner": false, "inclusive": false } }, # TODO
 	{ "keys": ["a", "W"], "type": Motion, "motion": { "type": "text_object_word", "inner": false, "inclusive": false } }, # TODO
 	{ "keys": ["i", "w"], "type": Motion, "motion": { "type": "text_object_word", "inner": true, "inclusive": true } },
 	{ "keys": ["i", "W"], "type": Motion, "motion": { "type": "text_object_word", "inner": true, "big_word": true, "inclusive": true } },
-	{ "keys": ["a", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": false, "line_wise": true } }, # TODO
 	{ "keys": ["i", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": true, "line_wise": true } },
+	{ "keys": ["a", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": false, "line_wise": true } }, # TODO
 	
 	{ "keys": ["i", "\""], "type": Motion, "motion": { "type": "text_object", "object": "\"", "inner": true, "inclusive": true, "inline": true } },
 	{ "keys": ["i", "'"], "type": Motion, "motion": { "type": "text_object", "object": "'", "inner": true, "inclusive": true, "inline": true } },
 	{ "keys": ["i", "`"], "type": Motion, "motion": { "type": "text_object", "object": "`", "inner": true, "inclusive": true, "inline": true } },
 	{ "keys": ["i", "("], "type": Motion, "motion": { "type": "text_object", "object": "(", "inner": true, "inclusive": true } },
+	{ "keys": ["i", ")"], "type": Motion, "motion": { "type": "text_object", "object": "(", "inner": true, "inclusive": true } },
 	{ "keys": ["i", "b"], "type": Motion, "motion": { "type": "text_object", "object": "(", "inner": true, "inclusive": true } },
 	{ "keys": ["i", "["], "type": Motion, "motion": { "type": "text_object", "object": "[", "inner": true, "inclusive": true } },
+	{ "keys": ["i", "]"], "type": Motion, "motion": { "type": "text_object", "object": "[", "inner": true, "inclusive": true } },
 	{ "keys": ["i", "{"], "type": Motion, "motion": { "type": "text_object", "object": "{", "inner": true, "inclusive": true } },
+	{ "keys": ["i", "}"], "type": Motion, "motion": { "type": "text_object", "object": "{", "inner": true, "inclusive": true } },
 	{ "keys": ["i", "B"], "type": Motion, "motion": { "type": "text_object", "object": "{", "inner": true, "inclusive": true } },
 	
 	# OPERATORS

--- a/addons/godot_vim/key_map.gd
+++ b/addons/godot_vim/key_map.gd
@@ -125,9 +125,13 @@ var key_map: Array[Dictionary] = [
 	{ "keys": ["n"], "type": Motion, "motion": { "type": "find_again", "forward": true } },
 	{ "keys": ["N"], "type": Motion, "motion": { "type": "find_again", "forward": false } },
 	
-	# Text objects
-	# { "keys": ["a", "w"], "type": Motion, "motion": { "type": "text_object_word", "inner": false, "inclusive": false } },
+	# TEXT OBJECTS
+	# { "keys": ["a", "w"], "type": Motion, "motion": { "type": "text_object_word", "inner": false, "inclusive": false } }, # TODO
+	# { "keys": ["a", "W"], "type": Motion, "motion": { "type": "text_object_word", "inner": false, "inclusive": false } }, # TODO
 	{ "keys": ["i", "w"], "type": Motion, "motion": { "type": "text_object_word", "inner": true, "inclusive": true } },
+	{ "keys": ["i", "W"], "type": Motion, "motion": { "type": "text_object_word", "inner": true, "big_word": true, "inclusive": true } },
+	# { "keys": ["a", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": false, "line_wise": true } }, # TODO
+	{ "keys": ["i", "p"], "type": Motion, "motion": { "type": "text_object_paragraph", "inner": true, "line_wise": true } },
 	
 	# OPERATORS
 	{ "keys": ["d"], "type": Operator, "operator": { "type": "delete" } },

--- a/addons/godot_vim/remap.gd
+++ b/addons/godot_vim/remap.gd
@@ -1,9 +1,5 @@
 class_name KeyRemap extends RefCounted
 
-# TODO Configure via JSON file or Project Settings (if feasible)
-# or create config.gd with user configs inside
-
-
 const Constants = preload("res://addons/godot_vim/constants.gd")
 const Mode = Constants.Mode
 


### PR DESCRIPTION
TL;DR: Adds:
- `iw iW`, `ip`, `i( i) ib`, `i[ i]`, `i{ i} iB`, `i" i'`, i\` as well as their "around" variations
- `%`
- `o` in visual mode
- `<C-u>`, and `<C-d>`

## Changes

- Adds `%` motion via `cursor::cmd_jump_to_next_brace_pair()`
- Adds word text objects (e.g. `iw`, `aW` in regular VIM) via `cursor::cmd_text_object_word()`
- Adds paragraph text objects (`ip`, `ap` in VIM) via `cursor::cmd_text_object_paragraph`
- Adds brace and quote text objects (e.g. `ib`, `a"` in VIM) via `cursor::cmd_text_object()`

> Note: text object functions return `Array[Vector2i]` containing start and end pos, instead of `Vector2i`

- Made it so `cursor::get_paragraph_edge_pos()` returns the line as an `int`, and made it more flexible
- Adds command `cursor::cmd_move_by_screen()`, which corresponds to `<C-u>` and `<C-d>` in regular VIM
- Adds `cursor::cmd_visual_jump_to_other_end()` (corresponds to `o` in visual mode in VIM)
- Adds multiple key options in keybinds
E.g. `{ "keys": ["i", ["(", ")", "b"]], ... }` would match `i`, and then either of `(`, `)`, or `b` for the same command, avoiding verbose repetitions.
(Before, you'd have to create a new keybind for `i(`, `i)`, and `ib`)
    - Adds `key_map::_do_keys_match()` to allow this
- Adds the ability to paste in `VISUAL_LINE` mode

### Helper functions

- Added function `cursor::find_brace()`, which also accounts for nested braces: `( () )`
- Added `cursor::find_next_occurrence_of_chars()`: searches for the next / previous occurrence of a character or set of characters
- Added `cursor::get_char_at()`, which avoids sporadic "Index out of bounds" errors and returns an empty String instead