### PR TITLE
Add condition to remove errors on launch 🐛

### DIFF
--- a/addons/godot_vim/plugin.gd
+++ b/addons/godot_vim/plugin.gd
@@ -257,6 +257,8 @@ func get_shader_tabcontainer():
 
 
 func _select(obj: Node, types: Array[String]):
+	if not obj:
+		return null
 	for type in types:
 		for child in obj.get_children():
 			if child.is_class(type):


### PR DESCRIPTION
When launching godot I got error: 
> [!Caution]
> res://addons/godot_vim/plugin.gd:261 - Cannot call method 'get_children' on a null value.
This is simple check to ensure that null value will not be called.