### PR TITLE
handle edge case at the very last line of a file for "new_line_below"

### DIFF
--- a/addons/godot_vim/cursor.gd
+++ b/addons/godot_vim/cursor.gd
@@ -869,9 +869,15 @@ func cmd_insert(args: Dictionary):
 			code_edit.get_first_non_whitespace_column(line)
 			+ int(code_edit.get_line(line).ends_with(":"))
 		)
-		code_edit.insert_line_at(
-			line + int(line < code_edit.get_line_count() - 1), "\t".repeat(ind)
-		)
+		if line == (code_edit.get_line_count() - 1):
+			code_edit.insert_line_at(
+				line + int(line < code_edit.get_line_count() - 1), code_edit.get_line(line)
+			)
+			code_edit.set_line(code_edit.get_caret_line(), "\t".repeat(ind))
+		else:
+			code_edit.insert_line_at(
+				line + int(line < code_edit.get_line_count() - 1), "\t".repeat(ind)
+			)
 		move_line(+1)
 		set_column(ind)
 		set_mode(Mode.INSERT)


### PR DESCRIPTION
kinda of mentioned in this issue https://github.com/bernardo-bruning/godot-vim/issues/21 but when editing a file in the godot editor and the cursor is at the very last line, the "new_line_below" offset makes a new line above the current line

actual:
<img width="997" alt="Screenshot 2024-09-26 at 4 35 03 PM" src="https://github.com/user-attachments/assets/55a657cf-5a6a-4959-90c2-f5143662c5f1">
<img width="997" alt="Screenshot 2024-09-26 at 4 35 14 PM" src="https://github.com/user-attachments/assets/fcce5ff1-acda-479e-96c9-1f09aba803d4">

expected:
<img width="997" alt="Screenshot 2024-09-26 at 4 35 59 PM" src="https://github.com/user-attachments/assets/65ca8765-9a61-4416-808a-96bf9056c65b">
<img width="997" alt="Screenshot 2024-09-26 at 4 36 04 PM" src="https://github.com/user-attachments/assets/59bfb74f-5ea9-445e-a5a2-69c91ddba6d7">
